### PR TITLE
Make tile replacement atomic even when only a limited number of tiles are rendered

### DIFF
--- a/modules/tiles/src/index.ts
+++ b/modules/tiles/src/index.ts
@@ -3,6 +3,7 @@
 export type {Tileset3DProps} from './tileset/tileset-3d';
 export {Tileset3D} from './tileset/tileset-3d';
 export {Tile3D} from './tileset/tile-3d';
+export {GroupedTilesArray} from './tileset/grouped-tiles.array';
 
 export {TilesetTraverser} from './tileset/tileset-traverser';
 export {TilesetCache} from './tileset/tileset-cache';

--- a/modules/tiles/src/tileset/grouped-tiles.array.ts
+++ b/modules/tiles/src/tileset/grouped-tiles.array.ts
@@ -2,7 +2,13 @@ import {Tile3D} from './tile-3d';
 import {TileGroup3D} from './tile-group-3d';
 
 export class GroupedTilesArray {
-  constructor(private readonly array: (Tile3D | TileGroup3D)[] = []) {}
+  private array: (Tile3D | TileGroup3D)[];
+
+  constructor(array?: (Tile3D | TileGroup3D)[]) {
+    // For some reason, the more concise 'private array: (Tile3D | TileGroup3D)[] = []'
+    // causes tests and imports to fail with errors about 'unexpected reserved keyword "private"'.
+    this.array = array ?? [];
+  }
 
   addTileOrGroup(other: Tile3D | TileGroup3D) {
     this.array.push(other);
@@ -56,14 +62,22 @@ export class GroupedTilesArray {
       return undefined;
     }
 
+    const highestPriority = this.array[minIndex];
+
+    // Remove the highest priority element from the array.
     this.array.splice(minIndex, 1);
 
-    return this.array[minIndex];
+    return highestPriority;
   }
 
   spliceHighestPriorityTilesOrGroups(maxNumTiles: number): GroupedTilesArray {
     if (maxNumTiles === 0 || this.numTiles() <= maxNumTiles) {
-      return this;
+      // Ensure that in all execution paths, the spliced tiles are returned in a
+      // separate object, while the (in this case, empty set of) unspliced tiles
+      // remain in the original object.
+      const selected = this.array;
+      this.array = [];
+      return new GroupedTilesArray(selected);
     }
 
     this.array.sort((a, b) => a._displayPriority - b._displayPriority);

--- a/modules/tiles/src/tileset/grouped-tiles.array.ts
+++ b/modules/tiles/src/tileset/grouped-tiles.array.ts
@@ -1,0 +1,88 @@
+import {Tile3D} from './tile-3d';
+import {TileGroup3D} from './tile-group-3d';
+
+export class GroupedTilesArray {
+  constructor(private readonly array: (Tile3D | TileGroup3D)[] = []) {}
+
+  addTileOrGroup(other: Tile3D | TileGroup3D) {
+    this.array.push(other);
+  }
+
+  addTilesOrGroups(other: GroupedTilesArray) {
+    this.array.push(...other.array);
+  }
+
+  numTiles() {
+    return this.array.reduce(
+      (total, group) => total + (group instanceof Tile3D ? 1 : group.tiles.length),
+      /* initial value */ 0
+    );
+  }
+
+  flatten(): Tile3D[] {
+    return this.array.flatMap((element) => (element instanceof Tile3D ? element : element.tiles));
+  }
+
+  forEach(callback: (tile: Tile3D) => void) {
+    for (const element of this.array) {
+      if (element instanceof Tile3D) {
+        callback(element);
+      } else {
+        element.tiles.forEach(callback);
+      }
+    }
+  }
+
+  /**
+   * Very similar to {@link spliceHighestPriorityTilesOrGroups}, but with two key differences:
+   *   1. If the highest-priority element is a group with multiple tiles,
+   *      {@link spliceHighestPriorityTilesOrGroups(1)} would return an empty array,
+   *      whereas this will return the group.
+   *   2. This is more efficient because it only performs the O(n) comparisons required to
+   *      find the min. It does not sort the entire array.
+   */
+  spliceHighestPriorityTileOrGroup(): Tile3D | TileGroup3D | undefined {
+    let minDisplayPriority = Number.MAX_VALUE;
+    let minIndex = -1;
+    for (let i = 0; i < this.array.length; i++) {
+      const group = this.array[i];
+      if (group._displayPriority < minDisplayPriority) {
+        minDisplayPriority = group._displayPriority;
+        minIndex = i;
+      }
+    }
+
+    if (minIndex === -1) {
+      return undefined;
+    }
+
+    this.array.splice(minIndex, 1);
+
+    return this.array[minIndex];
+  }
+
+  spliceHighestPriorityTilesOrGroups(maxNumTiles: number): GroupedTilesArray {
+    if (maxNumTiles === 0 || this.numTiles() <= maxNumTiles) {
+      return this;
+    }
+
+    this.array.sort((a, b) => a._displayPriority - b._displayPriority);
+
+    let i = 0;
+    let prospectiveSelectedTilesCount = 0;
+    for (i = 0; i < this.array.length - 1; i++) {
+      // Look ahead, see if the next element would overspill the maxNumTiles, and if so,
+      // return everything up to (but not including) the next element in order to stay
+      // strictly below the maxNumTiles limit.
+      const element = this.array[i + 1];
+      prospectiveSelectedTilesCount += element instanceof Tile3D ? 1 : element.tiles.length;
+      if (prospectiveSelectedTilesCount > maxNumTiles) {
+        break;
+      }
+    }
+
+    const selectedTileGroups = this.array.splice(0, i);
+
+    return new GroupedTilesArray(selectedTileGroups);
+  }
+}

--- a/modules/tiles/src/tileset/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset/helpers/frame-state.ts
@@ -1,9 +1,7 @@
-import {Tile3D} from '@loaders.gl/tiles';
 import {Vector3} from '@math.gl/core';
 import {CullingVolume, Plane} from '@math.gl/culling';
 import {Ellipsoid} from '@math.gl/geospatial';
 import {GeospatialViewport, Viewport} from '../../types';
-import {TileGroup3D} from '../tile-group-3d';
 
 export type FrameState = {
   camera: {
@@ -88,51 +86,6 @@ export function getFrameState(viewport: GeospatialViewport, frameNumber: number)
     frameNumber, // TODO: This can be the same between updates, what number is unique for between updates?
     sseDenominator: 1.15 // Assumes fovy = 60 degrees
   };
-}
-
-export function countTiles(groups: (Tile3D | TileGroup3D)[]): number {
-  return groups.reduce(
-    (total, group) => total + (group instanceof Tile3D ? 1 : group.tiles.length),
-    /* initial value */ 0
-  );
-}
-
-export function flattenTileGroups(groups: (Tile3D | TileGroup3D)[]): Tile3D[] {
-  return groups.flatMap((group) => (group instanceof Tile3D ? group : group.tiles));
-}
-
-/**
- * Limit `tiles` array length with `maximumTilesSelected` number.
- * The criteria for this filtering is distance of a tile center
- * to the `frameState.viewport`'s longitude and latitude
- * @param tileGroups - tiles array to filter
- * @param frameState - frameState to calculate distances
- * @param maximumTilesSelected - maximal amount of tiles in the output array
- * @returns new tiles array
- */
-export function limitSelectedTiles(
-  tileGroups: (Tile3D | TileGroup3D)[],
-  maximumTilesSelected: number
-): [(Tile3D | TileGroup3D)[], (Tile3D | TileGroup3D)[]] {
-  if (maximumTilesSelected === 0 || countTiles(tileGroups) <= maximumTilesSelected) {
-    return [tileGroups, []];
-  }
-
-  tileGroups.sort((a, b) => a._displayPriority - b._displayPriority);
-
-  let i = 0;
-  let selectedTilesCount = 0;
-  for (i = 0; i < tileGroups.length; i++) {
-    const group = tileGroups[i];
-    selectedTilesCount += group instanceof Tile3D ? 1 : group.tiles.length;
-    if (selectedTilesCount >= maximumTilesSelected) {
-      break;
-    }
-  }
-
-  const selectedTileGroups = tileGroups.splice(0, i);
-
-  return [selectedTileGroups, tileGroups];
 }
 
 function commonSpacePlanesToWGS84(viewport) {

--- a/modules/tiles/src/tileset/helpers/frame-state.ts
+++ b/modules/tiles/src/tileset/helpers/frame-state.ts
@@ -123,8 +123,8 @@ export function limitSelectedTiles(
   let i = 0;
   let selectedTilesCount = 0;
   for (i = 0; i < tileGroups.length; i++) {
-    const tile = tileGroups[i];
-    selectedTilesCount += tile instanceof Tile3D ? 1 : tile.tiles.length;
+    const group = tileGroups[i];
+    selectedTilesCount += group instanceof Tile3D ? 1 : group.tiles.length;
     if (selectedTilesCount >= maximumTilesSelected) {
       break;
     }

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -129,6 +129,19 @@ export class Tile3D {
   _visitedFrame: number = 0;
   _inRequestVolume: boolean = false;
   _lodJudge: any = null; // TODO i3s specific, needs to remove
+  _intersectsCullingVolume: boolean = false;
+
+  // the ID of the highest tile in the hierarchy that this tile is replacing
+  // for example:
+  //                 1. Full replace    2. Replace and add    3. Add and replace
+  //                     A (REPLACE)        A (REPLACE)           A (ADD)
+  //                     |                  |                     |
+  //                     B (REPLACE)        B (ADD)               B (REPLACE)
+  //                     |                  |                     |
+  //                     C                  C                     C
+  //
+  // replacedTileId is:  A                  undefined             B
+  _replacedTileId?: string;
 
   /**
    * @constructs
@@ -480,6 +493,7 @@ export class Tile3D {
     this._visibilityPlaneMask = this.visibility(frameState, parentVisibilityPlaneMask); // Use parent's plane mask to speed up visibility test
     this._visible = this._visibilityPlaneMask !== CullingVolume.MASK_OUTSIDE;
     this._inRequestVolume = this.insideViewerRequestVolume(frameState);
+    this._intersectsCullingVolume = this.intersectsCullingVolume(frameState);
 
     this._frameNumber = frameState.frameNumber;
     this.viewportIds = viewportIds;
@@ -595,6 +609,11 @@ export class Tile3D {
     return (
       !viewerRequestVolume || viewerRequestVolume.distanceSquaredTo(frameState.camera.position) <= 0
     );
+  }
+
+  intersectsCullingVolume(frameState: FrameState) {
+    const cullingVolume = frameState.cullingVolume;
+    return cullingVolume.computeVisibility(this.boundingVolume) >= 0;
   }
 
   // TODO Cesium specific

--- a/modules/tiles/src/tileset/tile-3d.ts
+++ b/modules/tiles/src/tileset/tile-3d.ts
@@ -129,7 +129,6 @@ export class Tile3D {
   _visitedFrame: number = 0;
   _inRequestVolume: boolean = false;
   _lodJudge: any = null; // TODO i3s specific, needs to remove
-  _intersectsCullingVolume: boolean = false;
 
   // the ID of the highest tile in the hierarchy that this tile is replacing
   // for example:
@@ -493,7 +492,6 @@ export class Tile3D {
     this._visibilityPlaneMask = this.visibility(frameState, parentVisibilityPlaneMask); // Use parent's plane mask to speed up visibility test
     this._visible = this._visibilityPlaneMask !== CullingVolume.MASK_OUTSIDE;
     this._inRequestVolume = this.insideViewerRequestVolume(frameState);
-    this._intersectsCullingVolume = this.intersectsCullingVolume(frameState);
 
     this._frameNumber = frameState.frameNumber;
     this.viewportIds = viewportIds;
@@ -609,11 +607,6 @@ export class Tile3D {
     return (
       !viewerRequestVolume || viewerRequestVolume.distanceSquaredTo(frameState.camera.position) <= 0
     );
-  }
-
-  intersectsCullingVolume(frameState: FrameState) {
-    const cullingVolume = frameState.cullingVolume;
-    return cullingVolume.computeVisibility(this.boundingVolume) >= 0;
   }
 
   // TODO Cesium specific

--- a/modules/tiles/src/tileset/tile-group-3d.ts
+++ b/modules/tiles/src/tileset/tile-group-3d.ts
@@ -6,6 +6,6 @@ export class TileGroup3D {
 
   addTile(tile: Tile3D) {
     this.tiles.push(tile);
-    this._displayPriority = Math.min(this._displayPriority, tile._screenSpaceError);
+    this._displayPriority = Math.min(this._displayPriority, tile._displayPriority);
   }
 }

--- a/modules/tiles/src/tileset/tile-group-3d.ts
+++ b/modules/tiles/src/tileset/tile-group-3d.ts
@@ -1,0 +1,11 @@
+import {Tile3D} from './tile-3d';
+
+export class TileGroup3D {
+  _displayPriority = Number.MAX_VALUE;
+  tiles: Tile3D[] = [];
+
+  addTile(tile: Tile3D) {
+    this.tiles.push(tile);
+    this._displayPriority = Math.min(this._displayPriority, tile._screenSpaceError);
+  }
+}

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -473,7 +473,11 @@ export class Tileset3D {
   _onTraversalEnd(frameState: FrameState): void {
     const id = frameState.viewport.id;
     if (!this.frameStateData[id]) {
-      this.frameStateData[id] = {selectedTileGroups: [], _requestedTiles: [], _emptyTiles: []};
+      this.frameStateData[id] = {
+        selectedTileGroups: new GroupedTilesArray(),
+        _requestedTiles: [],
+        _emptyTiles: []
+      };
     }
     const currentFrameStateData = this.frameStateData[id];
     const tiles = new GroupedTilesArray(Object.values(this._traverser.selectedTileGroups));

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -259,7 +259,6 @@ export class Tileset3D {
 
   /** Hold traversal results */
   selectedTileGroups: (Tile3D | TileGroup3D)[] = [];
-  intersectsCullingVolume: boolean = false;
 
   // TRAVERSAL
   traverseCounter: number = 0;

--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -258,7 +258,9 @@ export class TilesetTraverser {
       // Tileset structure and tile refinement modes are assumed to be static, so it should
       // only be necessary to set the replacedTileId once, on load.
       if (tile.parent?.refine === TILE_REFINEMENT.REPLACE) {
-        tile._replacedTileId = tile.parent._replacedTileId ?? tile.parent.id;
+        // The root tile of a tileset does not have an ID, so when the tileset root is a REPLACE
+        // tile , its children set the _replacedTileId to the URL for the whole tileset.
+        tile._replacedTileId = tile.parent._replacedTileId ?? tile.parent.id ?? tile.tileset.url;
       }
     }
   }

--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -267,9 +267,6 @@ export class TilesetTraverser {
   touchTile(tile: Tile3D, frameState: FrameState): void {
     tile.tileset._cache.touch(tile);
 
-    tile.tileset.intersectsCullingVolume =
-      tile.tileset.intersectsCullingVolume || tile._intersectsCullingVolume;
-
     // update priority if we havn't already this frame
     if (tile._touchedFrame !== frameState.frameNumber) {
       tile._displayPriority = tile._getDisplayPriority();

--- a/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
@@ -4,7 +4,7 @@
 import test from 'tape-promise/tape';
 import {WebMercatorViewport} from '@deck.gl/core';
 import {load} from '@loaders.gl/core';
-import {Tileset3D} from '@loaders.gl/tiles';
+import {Tile3D, Tileset3D} from '@loaders.gl/tiles';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 // import {loadTileset} from '../utils/load-utils';
 
@@ -170,7 +170,7 @@ test('Tileset3D#one viewport traversal', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTiles.length, 1);
+      t.equals(tileset.selectedTileGroups.length, 1);
     }
   }, 100);
 });
@@ -186,7 +186,7 @@ test('Tileset3D#onTraversalComplete', async (t) => {
       tileLoadCounter++;
     },
     onTraversalComplete: (selectedTiles) => {
-      return selectedTiles.filter((tile) => tile.depth === 1);
+      return selectedTiles.filter((tile) => tile instanceof Tile3D && tile.depth === 1);
     }
   });
   tileset.update(viewport);
@@ -196,7 +196,7 @@ test('Tileset3D#onTraversalComplete', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTiles.length, 4);
+      t.equals(tileset.selectedTileGroups.length, 4);
     }
   }, 100);
 });
@@ -219,13 +219,17 @@ test('Tileset3D#two viewports traversal', async (t) => {
     if (tileLoadCounter > 2) {
       clearInterval(setIntervalId);
       tileset.update(viewports);
-      t.equals(tileset.selectedTiles.length, 6);
+      t.equals(tileset.selectedTileGroups.length, 6);
       t.equals(
-        tileset.selectedTiles.filter((tile) => tile.viewportIds.includes('view0')).length,
+        tileset.selectedTileGroups.filter(
+          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view0')
+        ).length,
         1
       );
       t.equals(
-        tileset.selectedTiles.filter((tile) => tile.viewportIds.includes('view1')).length,
+        tileset.selectedTileGroups.filter(
+          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view1')
+        ).length,
         5
       );
     }
@@ -255,13 +259,17 @@ test('Tileset3D#viewportTraversersMap (one viewport shows tiles selected for ano
     if (tileLoadCounter > 1) {
       clearInterval(setIntervalId);
       tileset.update(viewports);
-      t.equals(tileset.selectedTiles.length, 5);
+      t.equals(tileset.selectedTileGroups.length, 5);
       t.equals(
-        tileset.selectedTiles.filter((tile) => tile.viewportIds.includes('view0')).length,
+        tileset.selectedTileGroups.filter(
+          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view0')
+        ).length,
         5
       );
       t.equals(
-        tileset.selectedTiles.filter((tile) => tile.viewportIds.includes('view1')).length,
+        tileset.selectedTileGroups.filter(
+          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view1')
+        ).length,
         5
       );
     }
@@ -287,7 +295,7 @@ test('Tileset3D#loadTiles option', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTiles.length, 1);
+      t.equals(tileset.selectedTileGroups.length, 1);
       tileLoadCounter = 0;
 
       viewport = VIEWPORTS[1];

--- a/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
+++ b/modules/tiles/test/tileset/tileset-3d-traversal.spec.ts
@@ -4,7 +4,7 @@
 import test from 'tape-promise/tape';
 import {WebMercatorViewport} from '@deck.gl/core';
 import {load} from '@loaders.gl/core';
-import {Tile3D, Tileset3D} from '@loaders.gl/tiles';
+import {GroupedTilesArray, Tileset3D} from '@loaders.gl/tiles';
 import {Tiles3DLoader} from '@loaders.gl/3d-tiles';
 // import {loadTileset} from '../utils/load-utils';
 
@@ -170,7 +170,7 @@ test('Tileset3D#one viewport traversal', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTileGroups.length, 1);
+      t.equals(tileset.selectedTileGroups.numTiles(), 1);
     }
   }, 100);
 });
@@ -186,7 +186,7 @@ test('Tileset3D#onTraversalComplete', async (t) => {
       tileLoadCounter++;
     },
     onTraversalComplete: (selectedTiles) => {
-      return selectedTiles.filter((tile) => tile instanceof Tile3D && tile.depth === 1);
+      return new GroupedTilesArray(selectedTiles.flatten().filter((tile) => tile.depth === 1));
     }
   });
   tileset.update(viewport);
@@ -196,7 +196,7 @@ test('Tileset3D#onTraversalComplete', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTileGroups.length, 4);
+      t.equals(tileset.selectedTileGroups.numTiles(), 4);
     }
   }, 100);
 });
@@ -219,17 +219,15 @@ test('Tileset3D#two viewports traversal', async (t) => {
     if (tileLoadCounter > 2) {
       clearInterval(setIntervalId);
       tileset.update(viewports);
-      t.equals(tileset.selectedTileGroups.length, 6);
+      t.equals(tileset.selectedTileGroups.numTiles(), 6);
       t.equals(
-        tileset.selectedTileGroups.filter(
-          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view0')
-        ).length,
+        tileset.selectedTileGroups.flatten().filter((tile) => tile.viewportIds.includes('view0'))
+          .length,
         1
       );
       t.equals(
-        tileset.selectedTileGroups.filter(
-          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view1')
-        ).length,
+        tileset.selectedTileGroups.flatten().filter((tile) => tile.viewportIds.includes('view1'))
+          .length,
         5
       );
     }
@@ -259,17 +257,15 @@ test('Tileset3D#viewportTraversersMap (one viewport shows tiles selected for ano
     if (tileLoadCounter > 1) {
       clearInterval(setIntervalId);
       tileset.update(viewports);
-      t.equals(tileset.selectedTileGroups.length, 5);
+      t.equals(tileset.selectedTileGroups.numTiles(), 5);
       t.equals(
-        tileset.selectedTileGroups.filter(
-          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view0')
-        ).length,
+        tileset.selectedTileGroups.flatten().filter((tile) => tile.viewportIds.includes('view0'))
+          .length,
         5
       );
       t.equals(
-        tileset.selectedTileGroups.filter(
-          (tile) => tile instanceof Tile3D && tile.viewportIds.includes('view1')
-        ).length,
+        tileset.selectedTileGroups.flatten().filter((tile) => tile.viewportIds.includes('view1'))
+          .length,
         5
       );
     }
@@ -295,7 +291,7 @@ test('Tileset3D#loadTiles option', async (t) => {
     if (tileLoadCounter > 0) {
       clearInterval(setIntervalId);
       tileset.update(viewport);
-      t.equals(tileset.selectedTileGroups.length, 1);
+      t.equals(tileset.selectedTileGroups.numTiles(), 1);
       tileLoadCounter = 0;
 
       viewport = VIEWPORTS[1];


### PR DESCRIPTION
Grouping selected tiles by the ancestor they replace helps make tile replacements atomic.

### Why & How

Add a `_replacedTileId` field which is set during traversal to the highest REPLACE-reachable ancestor tile ("REPLACE-reachable" means that all the intervening tiles are REPLACE tiles). This allows us to efficiently group tiles which belong to a single "replacement group," a group of tiles which collectively represent a geometry and therefore which must be displayed atomically (either all together, or not at all).

When applying the `maxTileCount` threshold, we iterate over all the tile groups, ranking each tile group according to its highest-priority displayPriority and including tile groups atomically.

This ensures that REPLACE geometries are always fully represented.
