### PR TITLE
Dataviz 2227 add root view distance scale property to tileset props

### DIFF
--- a/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
@@ -122,6 +122,10 @@ export function getDynamicScreenSpaceError(tileset, distanceToCamera) {
   return 0;
 }
 
+function defined(x: unknown): boolean {
+  return x !== undefined && x !== null;
+}
+
 export function getTiles3DScreenSpaceError(tile, frameState, useParentLodMetric) {
   const tileset = tile.tileset;
   const parentLodMetricValue = (tile.parent && tile.parent.lodMetricValue) || tile.lodMetricValue;
@@ -140,8 +144,7 @@ export function getTiles3DScreenSpaceError(tile, frameState, useParentLodMetric)
   const {height, sseDenominator} = frameState;
   const {viewDistanceScale, rootViewDistanceScale} = tileset.options;
 
-  const isRoot = tile.parent === undefined;
-  const tileViewDistanceScale = isRoot
+  const tileViewDistanceScale = !defined(tile.parent)
     ? rootViewDistanceScale ?? viewDistanceScale
     : viewDistanceScale;
 

--- a/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
+++ b/modules/tiles/src/tileset/helpers/tiles-3d-lod.ts
@@ -138,8 +138,15 @@ export function getTiles3DScreenSpaceError(tile, frameState, useParentLodMetric)
   // Avoid divide by zero when viewer is inside the tile
   const distance = Math.max(tile._distanceToCamera, 1e-7);
   const {height, sseDenominator} = frameState;
-  const {viewDistanceScale} = tileset.options;
-  let error = (lodMetricValue * height * (viewDistanceScale || 1.0)) / (distance * sseDenominator);
+  const {viewDistanceScale, rootViewDistanceScale} = tileset.options;
+
+  const isRoot = tile.parent === undefined;
+  const tileViewDistanceScale = isRoot
+    ? rootViewDistanceScale ?? viewDistanceScale
+    : viewDistanceScale;
+
+  let error =
+    (lodMetricValue * height * (tileViewDistanceScale || 1.0)) / (distance * sseDenominator);
 
   error -= getDynamicScreenSpaceError(tileset, distance);
 

--- a/modules/tiles/src/tileset/tileset-3d.ts
+++ b/modules/tiles/src/tileset/tileset-3d.ts
@@ -68,6 +68,7 @@ export type Tileset3DProps = {
   viewportTraversersMap?: any;
   updateTransforms?: boolean;
   viewDistanceScale?: number;
+  rootViewDistanceScale?: number;
 
   // Callbacks
   onTileLoad?: (tile: Tile3D) => any;
@@ -109,6 +110,14 @@ type Props = {
   updateTransforms: boolean;
   /** View distance scale modifier */
   viewDistanceScale: number;
+  /**
+   * Almost always this should NOT be set.
+   * It becomes useful if the root tile of the tileset has a geometric error calculated differently to the rest of the tiles.
+   * E.g. the root GE is simply the diagonal of the tiles bounds but the rest of the tiles have a more involved calculation.
+   * In such a case the root may require a different scale factor to the rest of the tiles.
+   * If this property is undefined, then the `viewDistanceScale` is used. If both are undefined the default of 1.0 is used.
+   */
+  rootViewDistanceScale?: number;
   basePath: string;
   /** Optional async tile content loader */
   contentLoader?: (tile: Tile3D) => Promise<void>;


### PR DESCRIPTION
Add a `rootViewDistanceScale` property to the tileset props primarily so we can prevent scaling the root tile. 