### PR TITLE
DV: Fix REPLACE tiles never being selected in some cases

### DIFF
--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -244,7 +244,13 @@ export class TilesetTraverser {
         selected.addTile(tile);
         return;
       }
-      this.selectedTileGroups[tile.id] = tile;
+
+      if (tile.refine !== TILE_REFINEMENT.REPLACE) {
+        // don't set the tile for REPLACE tiles as that should be handled above.
+        // if we do, we'll never select the refined tiles as we'll have put a tile
+        // instead of a TileGroup3D in the selectedTileGroups at that tile id.
+        this.selectedTileGroups[tile.id] = tile;
+      }
     }
   }
 


### PR DESCRIPTION
When we produce mesh tilesets, we usually end up creating a fake root tile to hold many children. This tile will have the `ADD` refinement strategy which meant that we would display the mesh properly. 

However, in some cases, we end up with a singular root tile if the file is particularly simple (as seen [here](https://sensat.slack.com/archives/CRF5WEMG8/p1725298841290979)). In this case, the root tile has a `REPLACE` refinement strategy, and so we will add a `Tile3D` to the `selectedTileGroups` rather than a `TileGroup3D`. This means that our replacement handling code will get stuck and throw the warnings that we've seen on a few projects. This would result in us downloading but never actually displaying the child tiles content (as it would never be selected properly).

Instead, we only set the `selectedTileGroups` values for non-`REPLACE` tiles.

Before:
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/ae0350d6-d4c0-426b-b6ea-61a1e20ea35d">


After:
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/f271c837-14cd-4b9a-8dc6-ceb4518e4c8f">
