### PR TITLE
DV: Fix replace tiles with no children not loading

### DIFF
--- a/modules/tiles/src/tileset/tileset-traverser.ts
+++ b/modules/tiles/src/tileset/tileset-traverser.ts
@@ -245,8 +245,8 @@ export class TilesetTraverser {
         return;
       }
 
-      if (tile.refine !== TILE_REFINEMENT.REPLACE) {
-        // don't set the tile for REPLACE tiles as that should be handled above.
+      if (tile.refine !== TILE_REFINEMENT.REPLACE || !tile.children.length) {
+        // don't set the tile for REPLACE tiles that have children as that should be handled above.
         // if we do, we'll never select the refined tiles as we'll have put a tile
         // instead of a TileGroup3D in the selectedTileGroups at that tile id.
         this.selectedTileGroups[tile.id] = tile;


### PR DESCRIPTION
Merged previous PR slightly too hastily 😬 

Cypress found an interesting edge case which is a file like EdenbridgeBox.ifc which is a single root node with no children AND a `REPLACE` refinement. This doesn't really many any sense, but we still need to handle it otherwise we won't be able to display the model.

Original file still works:
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/681cfe5f-9d61-4e4d-9097-71d744da6d2c">


Edenbridge box is also back:
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/59bbc62e-54d3-4133-9c83-ea64cfdff199">
